### PR TITLE
[Feat] optimisation du gestionnaire de scroll

### DIFF
--- a/public/workers/scrollWorker.js
+++ b/public/workers/scrollWorker.js
@@ -1,19 +1,34 @@
-self.onmessage = function(event) {
-    const { sections, scrollY } = event.data;
-    let currentSectionId = "";
+let sections = [];
+let positions = {};
 
-    // Déterminer la section visible
-    sections.forEach(({ id }) => {
-        const sectionTop = event.data.positions[id]?.top;
-        const sectionHeight = event.data.positions[id]?.height;
-        const isInView =
-            scrollY >= sectionTop - 100 && scrollY < sectionTop + sectionHeight;
+self.onmessage = function (event) {
+  const {
+    sections: incomingSections,
+    positions: incomingPositions,
+    scrollY,
+  } = event.data;
 
-        if (isInView) {
-            currentSectionId = id;
-        }
-    });
+  if (incomingSections && incomingPositions) {
+    sections = incomingSections;
+    positions = incomingPositions;
+  }
 
-    // Retourner la section active au main thread
-    self.postMessage({ currentSectionId });
+  if (typeof scrollY !== "number") return;
+
+  let currentSectionId = "";
+
+  // Déterminer la section visible
+  sections.forEach(({ id }) => {
+    const sectionTop = positions[id]?.top;
+    const sectionHeight = positions[id]?.height;
+    const isInView =
+      scrollY >= sectionTop - 100 && scrollY < sectionTop + sectionHeight;
+
+    if (isInView) {
+      currentSectionId = id;
+    }
+  });
+
+  // Retourner la section active au main thread
+  self.postMessage({ currentSectionId });
 };

--- a/src/utils/addPassive.ts
+++ b/src/utils/addPassive.ts
@@ -1,0 +1,5 @@
+const addPassive = () => {
+  return { passive: true } as const;
+};
+
+export default addPassive;


### PR DESCRIPTION
## Description
- ajoute un utilitaire `addPassive`
- pré-calcule les positions des sections et cache ces valeurs côté worker
- n'envoie plus que `scrollY` pendant le scroll

## Tests effectués
- `npx prettier --write app/useScrollAnchors.ts src/utils/addPassive.ts public/workers/scrollWorker.js`
- `yarn lint` *(échoue : `next` introuvable)*
- `yarn build` *(échoue : `next` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4338839508324815d43b73145da9c