### PR TITLE
[Fix] Nettoie les contextes de navigation

### DIFF
--- a/src/utils/context/NavigationContext.tsx
+++ b/src/utils/context/NavigationContext.tsx
@@ -1,43 +1,42 @@
 import React, { createContext, useState, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
+
 interface NavigationContextType {
     currentRoute: string;
     updateRoute: (path: string) => void;
-    openSubMenu: string | null;
-    setOpenSubMenu: (subMenuId: string | null) => void;
     showNavLinks: boolean;
     setShowNavLinks: (showNavLinks: boolean) => void;
-    resetDisplayStyles: () => void;
     hamburgerMenuIsOpen: boolean;
     openHamburgerMenu: () => void;
     closeHamburgerMenu: (delay?: number) => void;
 }
+
 const NavigationContext = createContext<NavigationContextType | null>(null);
+
 const useNavigationState = () => {
     const router = useRouter();
     const pathname = usePathname();
     const [currentRoute, setCurrentRoute] = useState(pathname || "/");
-    const [openSubMenu, setOpenSubMenu] = useState<string | null>(null);
     const [showNavLinks, setShowNavLinks] = useState<boolean>(true);
     const [hamburgerMenuIsOpen, setHamburgerMenuIsOpen] = useState(false);
+
     useEffect(() => {
         setCurrentRoute(pathname || "/");
     }, [pathname]);
+
     const updateRoute = (path: string) => {
         setCurrentRoute(path);
         router.push(path);
     };
-    const resetDisplayStyles = () => setOpenSubMenu(null);
+
     const openHamburgerMenu = () => setHamburgerMenuIsOpen(true);
     const closeHamburgerMenu = (delay: number = 0) => {
         setTimeout(() => setHamburgerMenuIsOpen(false), delay);
     };
+
     return {
         currentRoute,
         updateRoute,
-        openSubMenu,
-        setOpenSubMenu,
-        resetDisplayStyles,
         showNavLinks,
         setShowNavLinks,
         hamburgerMenuIsOpen,
@@ -45,6 +44,7 @@ const useNavigationState = () => {
         closeHamburgerMenu,
     };
 };
+
 export const NavigationProvider: React.FC<{ children: React.ReactNode }> = ({
     children,
 }) => {
@@ -55,8 +55,11 @@ export const NavigationProvider: React.FC<{ children: React.ReactNode }> = ({
         </NavigationContext.Provider>
     );
 };
+
 import { createUseContext } from "./utils/createUseContext";
+
 export const useNavigation = createUseContext(
     NavigationContext,
-    "useNavigation"
+    "useNavigation",
 );
+

--- a/src/utils/context/ScrollContext.tsx
+++ b/src/utils/context/ScrollContext.tsx
@@ -1,4 +1,43 @@
-"use client";import{createContext,useState,useMemo,ReactNode}from"react";import{createUseContext}from"./utils/createUseContext";interface ScrollContextType{activeSection:string;setActiveSection:(section:string)=>void}const ScrollContext=createContext<ScrollContextType|undefined>(undefined);interface ScrollProviderProps{children:ReactNode}const ScrollProvider=({children}:ScrollProviderProps)=>{const[activeSection,setActiveSection]=useState<string>("");const contextValue=useMemo(()=>({activeSection,setActiveSection}),[activeSection]);return(<ScrollContext.Provider value={contextValue}>{children}</ScrollContext.Provider>
+"use client";
+
+import {
+    createContext,
+    useState,
+    useMemo,
+    ReactNode,
+} from "react";
+import { createUseContext } from "./utils/createUseContext";
+
+interface ScrollContextType {
+    activeSection: string;
+    setActiveSection: (section: string) => void;
+}
+
+const ScrollContext = createContext<ScrollContextType | undefined>(undefined);
+
+interface ScrollProviderProps {
+    children: ReactNode;
+}
+
+const ScrollProvider = ({ children }: ScrollProviderProps) => {
+    const [activeSection, setActiveSection] = useState<string>("");
+
+    const contextValue = useMemo(
+        () => ({ activeSection, setActiveSection }),
+        [activeSection],
     );
-};export default ScrollProvider;
-export const useScrollContext=createUseContext(ScrollContext,"useScrollContext");
+
+    return (
+        <ScrollContext.Provider value={contextValue}>
+            {children}
+        </ScrollContext.Provider>
+    );
+};
+
+export default ScrollProvider;
+
+export const useScrollContext = createUseContext(
+    ScrollContext,
+    "useScrollContext",
+);
+


### PR DESCRIPTION
## Description
- supprime la gestion `openSubMenu` du `NavigationContext` pour éviter des rendus inutiles
- réécrit `ScrollContext` avec une structure claire et typée

## Tests effectués
- `yarn lint`
- `yarn build`
- `yarn prettier --write …` *(échec : dépendance manquante/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4455eec8c83249958c60c9becc61e