### PR TITLE
[Fix] retirer force-dynamic du header

### DIFF
--- a/src/components/header/HeaderLazy.jsx
+++ b/src/components/header/HeaderLazy.jsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, lazy, Suspense } from "react";
 import useT from "../../hook/useTimeoutWorker";
-export const dynamic = "force-dynamic";
 import HeaderGhost from "./HeaderGhost";
 const HeaderWarpProvider = lazy(() => import("./HeaderWarpProvider"));
 const HeaderLazy = () => {


### PR DESCRIPTION
## Summary
- supprime l'export `dynamic` du composant `HeaderLazy`

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c51645c4e8832485ae0bbefcd9e8bc