### PR TITLE
[Feat] header client island

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 // import localFont from "next/font/local";
 import HeaderLazy from "../src/components/header/HeaderLazy";
 import ClientLayout from "./ClientLayout";
-// export const dynamic = "force-dynamic";
 
 /* const Montserrat = localFont({
     src: "./fonts/Montserrat.woff2",

--- a/src/components/header/HeaderLazy.jsx
+++ b/src/components/header/HeaderLazy.jsx
@@ -1,24 +1,15 @@
 "use client";
-import React, { useState, lazy, Suspense } from "react";
-import useT from "../../hook/useTimeoutWorker";
-// export const dynamic = "force-dynamic";
+import dynamic from "next/dynamic";
 import HeaderGhost from "./HeaderGhost";
-const HeaderWarpProvider = lazy(() => import("./HeaderWarpProvider"));
+
+const HeaderWarpProvider = dynamic(() => import("./HeaderWarpProvider"), {
+    ssr: false,
+    loading: () => <HeaderGhost />,
+});
+
 const HeaderLazy = () => {
-    const [showHeader, setShowHeader] = useState(false);
-
-    useT(() => {
-        setShowHeader(true);
-    }, 600);
-
-    if (!showHeader) {
-        return <HeaderGhost />;
-    }
-    return (
-        <Suspense fallback={<HeaderGhost />}>
-            <HeaderWarpProvider />
-        </Suspense>
-    );
+    return <HeaderWarpProvider />;
 };
 
-export default React.memo(HeaderLazy);
+export default HeaderLazy;
+

--- a/src/components/header/HeaderWarpProvider.jsx
+++ b/src/components/header/HeaderWarpProvider.jsx
@@ -14,4 +14,4 @@ const HeaderWarpProvider = () => {
     );
 };
 
-export default dynamic(() => Promise.resolve(React.memo(HeaderWarpProvider)));
+export default React.memo(HeaderWarpProvider);


### PR DESCRIPTION
## Description
- header dynamique côté client sans désactiver le cache statique
- simplification du provider pour réduire l'hydratation

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c51a9b767083248c0721dacedf9345