### PR TITLE
[Fix] ajustement tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "lib": ["DOM", "DOM.Iterable", "ES2022"],
+        "lib": ["ES2023", "DOM", "DOM.Iterable"],
         "allowJs": true,
         "skipLibCheck": true,
         "strict": true,
@@ -9,9 +9,11 @@
         "incremental": true,
         "module": "ESNext",
         "esModuleInterop": true,
-        "moduleResolution": "node",
+        "moduleResolution": "Bundler",
         "resolveJsonModule": true,
         "isolatedModules": true,
+        "useDefineForClassFields": true,
+        "verbatimModuleSyntax": true,
         "jsx": "preserve",
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
## Summary
- ajuster la résolution des modules pour utiliser Bundler
- activer les options TypeScript `useDefineForClassFields` et `verbatimModuleSyntax`
- mettre à jour la cible `lib` vers ES2023 et DOM

## Testing
- `yarn lint`
- `yarn prettier --write tsconfig.json` *(échoué : Couldn't find a script named "prettier")*
- `yarn dlx prettier --write tsconfig.json` *(échoué : Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c559695b4483248f1ec3e3ea650f53