### PR TITLE
[Feat] ajouter scripts legacy et mise à jour de lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint",
+        "lint": "eslint .",
         "generate:sitemap": "node /tools/scripts/generate-sitemap.js",
         "keep:list": "node /tools/scripts/keep-list.cjs",
         "keep": "yarn lint && node ./tools/scripts/keep-list.cjs && node ./tools/scripts/keep-functions.cjs",
         "keep:fn": "node /tools/scripts/keep-functions.cjs",
         "css:prune": "tsx tools/scripts/css-prune.ts",
-        "css:prune:apply": "tsx tools/scripts/css-prune.ts --apply"
+        "css:prune:apply": "tsx tools/scripts/css-prune.ts --apply",
+        "scan:legacy": "node scripts/legacy-scan.mjs",
+        "check:legacy": "node scripts/check-legacy-budget.mjs",
+        "trace:corejs": "node scripts/trace-corejs.mjs",
+        "fix:polyfills": "node scripts/remove-polyfills.mjs"
     },
     "dependencies": {
         "next": "15.5.3",


### PR DESCRIPTION
## Résumé
- ajout des scripts `scan:legacy`, `check:legacy`, `trace:corejs` et `fix:polyfills`
- remplacement de `next lint` par `eslint .` dans le script `lint`

## Tests
- `yarn install`
- `yarn dlx prettier --write package.json` *(échec: prettier introuvable)*
- `yarn lint` *(échec: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c56aaaa8988324b5dfe825e09b3677