### PR TITLE
[Feat] ignorer ESLint pendant les builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         // resolveAlias: { 'lodash': 'lodash-es', 'uuid': 'uuid/dist/esm-browser/index.js' },
     },
 
+    eslint: {
+        ignoreDuringBuilds: true,
+    },
+
     webpack: (config) => {
         // Préférer l’ESM quand dispo (utile si tu actives Webpack en prod)
         config.resolve.conditionNames = [


### PR DESCRIPTION
## Description
- ajout de `eslint.ignoreDuringBuilds` dans `next.config.ts`

## Tests effectués
- `yarn install`
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c56aa356dc8324b2f506f5fdc3b164