### PR TITLE
[Feat] migration vers ESLint flat

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,22 @@
+import next from 'eslint-config-next';
+
+export default [
+  ...next,
+  {
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            'core-js',
+            'core-js/stable',
+            'regenerator-runtime/runtime',
+            'whatwg-fetch',
+            'object-assign',
+          ],
+          patterns: ['react-app-polyfill/*'],
+        },
+      ],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint",
+        "lint": "eslint .",
         "generate:sitemap": "node /tools/scripts/generate-sitemap.js",
         "keep:list": "node /tools/scripts/keep-list.cjs",
         "keep": "yarn lint && node ./tools/scripts/keep-list.cjs && node ./tools/scripts/keep-functions.cjs",


### PR DESCRIPTION
## Summary
- remplace la configuration ESLint par le nouveau format flat et interdit certains imports obsolètes
- met à jour le script de lint pour utiliser `eslint .`

## Tests effectués
- `yarn dlx prettier --write eslint.config.mjs package.json` *(échoue : prettier@unknown can't be resolved)*
- `yarn lint` *(échoue : Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68c56a9e5c9c8324b3d46b4762419ca5