### PR TITLE
[Feat] script de suppression des polyfills

### DIFF
--- a/scripts/remove-polyfills.mjs
+++ b/scripts/remove-polyfills.mjs
@@ -1,0 +1,29 @@
+import { glob } from "glob";
+import fs from "node:fs/promises";
+
+const files = await glob("{app,pages,src}/**/*.{js,jsx,ts,tsx}");
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const modules = [
+  "core-js/stable",
+  "regenerator-runtime/runtime",
+  "whatwg-fetch",
+];
+const pattern = modules.map(escapeRegExp).join("|");
+const importRx = new RegExp(
+  `^\\s*(?:import\\s+['"](?:${pattern})['"];?|require\\(\\s*['"](?:${pattern})['"]\\s*\\);?)\\s*\\n?`,
+  "gm",
+);
+const scriptRx = new RegExp(
+  "<Script[^>]*src=[\"'][^\"']*polyfill\\.io[^\"']*[\"'][^>]*>(?:\\s*<\\/Script>)?|<Script[^>]*src=[\"'][^\"']*polyfill\\.io[^\"']*[\"'][^>]*\\/?>",
+  "g",
+);
+
+for (const f of files) {
+  const src = await fs.readFile(f, "utf8");
+  const cleaned = src.replace(importRx, "").replace(scriptRx, "");
+  if (cleaned !== src) {
+    await fs.writeFile(f, cleaned);
+    console.log(`Nettoyé ${f}`);
+  }
+}


### PR DESCRIPTION
## Description
- ajoute `scripts/remove-polyfills.mjs` pour retirer les imports globaux de polyfills et les balises `<Script>` vers polyfill.io

## Tests effectués
- `yarn install`
- `npx prettier scripts/remove-polyfills.mjs --write`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56a926be8832484eef429458f7032