### PR TITLE
[Fix] désactivation des polyfills Next

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -28,6 +29,33 @@ const nextConfig: NextConfig = {
                 ],
             },
         ];
+    },
+    turbopack: {
+        resolveAlias: {
+            "@next/polyfill-module": path.resolve(
+                __dirname,
+                "src/shims/next-polyfills-empty.js",
+            ),
+            "next/dist/build/polyfills/polyfill-module.js": path.resolve(
+                __dirname,
+                "src/shims/next-polyfills-empty.js",
+            ),
+        },
+    },
+    webpack: (config) => {
+        config.resolve = config.resolve || {};
+        config.resolve.alias = {
+            ...(config.resolve.alias || {}),
+            "@next/polyfill-module": path.resolve(
+                __dirname,
+                "src/shims/next-polyfills-empty.js",
+            ),
+            "next/dist/build/polyfills/polyfill-module.js": path.resolve(
+                __dirname,
+                "src/shims/next-polyfills-empty.js",
+            ),
+        };
+        return config;
     },
 };
 

--- a/src/shims/next-polyfills-empty.js
+++ b/src/shims/next-polyfills-empty.js
@@ -1,0 +1,2 @@
+// no-op: we target modern browsers; do not ship Next polyfills
+export {};


### PR DESCRIPTION
## Objectif
- ne plus charger les polyfills Next.js pour les navigateurs modernes

## Modifications
- ajout d'un shim `next-polyfills-empty.js`
- configuration de Turbopack et Webpack pour pointer vers ce shim

## Tests effectués
- `yarn install` *(échec: RequestError 403)*
- `yarn lint`
- `rm -rf .next && yarn build`
- `grep -R "polyfill-module" .next/static || true`


------
https://chatgpt.com/codex/tasks/task_e_68c572c17c9c832493b931e020a9772a