### PR TITLE
[Feat] centralise navigation handlers

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -5,34 +5,20 @@ import { usePathname } from "next/navigation";
 import Nav from "./Nav";
 import { useScrollContext } from "@utils/context/ScrollContext";
 import { useNavigation } from "@utils/context/NavigationContext";
-import { MenuItem, menuItems } from "@assets/data/menuItems";
+import { menuItems } from "@assets/data/menuItems";
 import { updateMenuClasses } from "@utils/updateMenuUtils";
-import { useSmoothScroll } from "@utils/useSmoothScroll";
 import { useInitialScroll } from "@utils/scrollUtils";
-import { makeClickHandler } from "@utils/handlers";
+import { useNavigationHandlers } from "@hooks/useNavigationHandlers";
+import { NavigationHandlerProvider } from "@utils/context/NavigationHandlerContext";
 
-interface NavProps {
-    menuItems: MenuItem[];
-    onNavigationClick: (path: string) => void;
-}
-
-const Header: React.FC<NavProps> = () => {
+const Header: React.FC = () => {
     const pathname = usePathname();
-    const { currentRoute, updateRoute, closeHamburgerMenu } = useNavigation();
+    const { currentRoute } = useNavigation();
     const { activeSection } = useScrollContext();
 
     useInitialScroll(pathname);
 
-    const handleNavigationClick = useSmoothScroll(currentRoute, updateRoute);
-
-    const handleLogoClick = useMemo(
-        () =>
-            makeClickHandler(() => {
-                closeHamburgerMenu(200);
-                handleNavigationClick("/#top");
-            }),
-        [closeHamburgerMenu, handleNavigationClick]
-    );
+    const { handleNavigationClick, handleLogoClick } = useNavigationHandlers();
 
     const updatedMenuItems = useMemo(
         () => updateMenuClasses(menuItems.mainLink, activeSection, currentRoute),
@@ -40,10 +26,12 @@ const Header: React.FC<NavProps> = () => {
     );
 
     return (
-        <div className="ha header">
-            <LogoLink onClick={handleLogoClick} />
-            <Nav menuItems={updatedMenuItems} onNavigationClick={handleNavigationClick} />
-        </div>
+        <NavigationHandlerProvider value={{ onNavigationClick: handleNavigationClick }}>
+            <div className="ha header">
+                <LogoLink onClick={handleLogoClick} />
+                <Nav menuItems={updatedMenuItems} />
+            </div>
+        </NavigationHandlerProvider>
     );
 };
 

--- a/src/components/header/MenuList.tsx
+++ b/src/components/header/MenuList.tsx
@@ -1,32 +1,29 @@
-import { useMemo, memo } from "react";
+import { useMemo, memo, useCallback } from "react";
 import { MenuItem } from "../../assets/data/menuItems";
 import NavLink from "./NavLink";
 
 interface MenuListProps {
     menuItems: MenuItem[];
     openSubMenu: string | null;
-    onNavigationClick: (path: string) => void;
     handleMenuClick: (menuItemId: string) => void;
 }
 
-const MenuList: React.FC<MenuListProps> = ({
-    menuItems,
-    openSubMenu,
-    onNavigationClick,
-    handleMenuClick,
-}) => {
+const MenuList: React.FC<MenuListProps> = ({ menuItems, openSubMenu, handleMenuClick }) => {
+    const renderNavLink = useCallback(
+        (menuItem: MenuItem) => (
+            <NavLink
+                key={menuItem.id}
+                menuItem={menuItem}
+                isOpen={openSubMenu === menuItem.id}
+                handleMenuClick={handleMenuClick}
+            />
+        ),
+        [openSubMenu, handleMenuClick]
+    );
+
     const renderedMenuItems = useMemo(
-        () =>
-            menuItems.map((menuItem) => (
-                <NavLink
-                    key={menuItem.id}
-                    menuItem={menuItem}
-                    onNavigationClick={onNavigationClick}
-                    isOpen={openSubMenu === menuItem.id}
-                    handleMenuClick={handleMenuClick}
-                />
-            )),
-        [menuItems, openSubMenu, onNavigationClick, handleMenuClick]
+        () => menuItems.map(renderNavLink),
+        [menuItems, renderNavLink]
     );
 
     return <nav className="main-nav">{renderedMenuItems}</nav>;

--- a/src/components/header/MenuOpen.tsx
+++ b/src/components/header/MenuOpen.tsx
@@ -6,10 +6,9 @@ interface NavProps {
     menuItems: {
         mainLink?: MenuItem[];
     };
-    onNavigationClick: (path: string) => void;
 }
 
-const MenuOpen: React.FC<NavProps> = ({ menuItems, onNavigationClick }) => {
+const MenuOpen: React.FC<NavProps> = ({ menuItems }) => {
     const { hamburgerMenuIsOpen, openSubMenu, setOpenSubMenu } = useNavigation();
 
     const handleMenuClick = useCallback(
@@ -30,7 +29,6 @@ const MenuOpen: React.FC<NavProps> = ({ menuItems, onNavigationClick }) => {
                 <MenuList
                     menuItems={menuItems.mainLink}
                     openSubMenu={openSubMenu}
-                    onNavigationClick={onNavigationClick}
                     handleMenuClick={handleMenuClick}
                 />
             )}

--- a/src/components/header/Nav.tsx
+++ b/src/components/header/Nav.tsx
@@ -6,14 +6,13 @@ interface NavProps {
     menuItems: {
         mainLink?: MenuItem[];
     };
-    onNavigationClick: (path: string) => void;
 }
 
-const Nav: React.FC<NavProps> = ({ menuItems, onNavigationClick }) => {
+const Nav: React.FC<NavProps> = ({ menuItems }) => {
     return (
         <>
             <ButtonOpen />
-            <MenuOpen menuItems={menuItems} onNavigationClick={onNavigationClick} />
+            <MenuOpen menuItems={menuItems} />
         </>
     );
 };

--- a/src/components/header/NavLink.tsx
+++ b/src/components/header/NavLink.tsx
@@ -6,27 +6,22 @@ import type { MenuItem } from "../../assets/data/menuItems";
 import { useNavigation } from "../../utils/context/NavigationContext";
 import { svgComponents } from "./svgComponents";
 import { makeClickHandler } from "@utils/handlers";
+import { useNavigationHandler } from "@utils/context/NavigationHandlerContext";
 
 const LazySubMenu = dynamic<{
     menuItem: MenuItem;
     isOpen: boolean;
-    onSubItemClick: (path: string) => void;
 }>(() => import("./SubMenu"), { ssr: false, loading: () => null });
 
 interface NavLinkProps {
     menuItem: MenuItem;
-    onNavigationClick: (path: string) => void;
     isOpen: boolean;
     handleMenuClick: (menuItemId: string) => void;
 }
 
-const NavLink: React.FC<NavLinkProps> = ({
-    menuItem,
-    onNavigationClick,
-    isOpen,
-    handleMenuClick,
-}) => {
+const NavLink: React.FC<NavLinkProps> = ({ menuItem, isOpen, handleMenuClick }) => {
     const { closeHamburgerMenu } = useNavigation();
+    const { onNavigationClick } = useNavigationHandler();
     const SvgIcon = useMemo(() => svgComponents[menuItem.svg], [menuItem.svg]);
 
     const handleClick = useMemo(
@@ -42,13 +37,13 @@ const NavLink: React.FC<NavLinkProps> = ({
                 }
             }),
         [
-            onNavigationClick,
             menuItem.path,
             menuItem.id,
             menuItem.subItems?.length,
             isOpen,
             handleMenuClick,
             closeHamburgerMenu,
+            onNavigationClick,
         ]
     );
 
@@ -76,13 +71,7 @@ const NavLink: React.FC<NavLinkProps> = ({
             </a>
 
             {/* Sous-menu chargé seulement quand c’est ouvert */}
-            {hasSub && isOpen && (
-                <LazySubMenu
-                    menuItem={menuItem}
-                    isOpen={isOpen}
-                    onSubItemClick={onNavigationClick}
-                />
-            )}
+            {hasSub && isOpen && <LazySubMenu menuItem={menuItem} isOpen={isOpen} />}
         </div>
     );
 };

--- a/src/components/header/SubMenu.tsx
+++ b/src/components/header/SubMenu.tsx
@@ -5,28 +5,29 @@ import { useMemo, memo } from "react";
 import { MenuItem } from "../../assets/data/menuItems";
 import { useNavigation } from "../../utils/context/NavigationContext";
 import { makePayloadClickHandler, makeActivationHandler } from "@utils/handlers";
+import { useNavigationHandler } from "@utils/context/NavigationHandlerContext";
 
 interface SubMenuProps {
     menuItem: MenuItem;
     isOpen: boolean;
-    onSubItemClick: (path: string) => void;
 }
 
-const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick }) => {
+const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen }) => {
     const { closeHamburgerMenu } = useNavigation();
+    const { onNavigationClick } = useNavigationHandler();
 
     const handleSubItemClick = useMemo(
         () =>
-            makePayloadClickHandler<string>(onSubItemClick, {
+            makePayloadClickHandler<string>(onNavigationClick, {
                 close: closeHamburgerMenu,
                 delay: 650,
             }),
-        [onSubItemClick, closeHamburgerMenu]
+        [onNavigationClick, closeHamburgerMenu]
     );
 
     const handleKeyDown = useMemo(
-        () => makeActivationHandler<string>(onSubItemClick),
-        [onSubItemClick]
+        () => makeActivationHandler<string>(onNavigationClick),
+        [onNavigationClick]
     );
 
     if (!menuItem.subItems || menuItem.subItems.length === 0) return null;

--- a/src/hooks/useNavigationHandlers.ts
+++ b/src/hooks/useNavigationHandlers.ts
@@ -1,0 +1,22 @@
+"use client";
+import { useMemo } from "react";
+import { useNavigation } from "@utils/context/NavigationContext";
+import { useSmoothScroll } from "@utils/useSmoothScroll";
+import { makeClickHandler } from "@utils/handlers";
+
+export const useNavigationHandlers = () => {
+    const { currentRoute, updateRoute, closeHamburgerMenu } = useNavigation();
+
+    const handleNavigationClick = useSmoothScroll(currentRoute, updateRoute);
+
+    const handleLogoClick = useMemo(
+        () =>
+            makeClickHandler(() => {
+                closeHamburgerMenu(200);
+                handleNavigationClick("/#top");
+            }),
+        [closeHamburgerMenu, handleNavigationClick]
+    );
+
+    return { handleNavigationClick, handleLogoClick } as const;
+};

--- a/src/utils/context/NavigationHandlerContext.tsx
+++ b/src/utils/context/NavigationHandlerContext.tsx
@@ -1,0 +1,24 @@
+import React, { createContext } from "react";
+import { createUseContext } from "./utils/createUseContext";
+
+interface NavigationHandlerContextType {
+    onNavigationClick: (path: string) => void;
+}
+
+const NavigationHandlerContext = createContext<NavigationHandlerContextType | null>(null);
+
+export const NavigationHandlerProvider: React.FC<{
+    value: NavigationHandlerContextType;
+    children: React.ReactNode;
+}> = ({ value, children }) => {
+    return (
+        <NavigationHandlerContext.Provider value={value}>
+            {children}
+        </NavigationHandlerContext.Provider>
+    );
+};
+
+export const useNavigationHandler = createUseContext(
+    NavigationHandlerContext,
+    "useNavigationHandler"
+);


### PR DESCRIPTION
## Summary
- centralize navigation logic via `useNavigationHandlers` and context to avoid prop drilling
- memoize menu components for improved rendering performance

## Testing
- `yarn install`
- `yarn lint`
- `yarn build --analyze` *(fails: unknown option)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c813f412348324b8921c4fb161124a